### PR TITLE
fix: import tensorrt before nvvfx to prevent dynamic library conflicts

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,8 @@
 import torch
+try:
+    import tensorrt
+except ImportError:
+    pass
 import nvvfx
 from enum import Enum
 from typing import TypedDict


### PR DESCRIPTION
nvvfx bundles its own older version of the TensorRT runtime library (libnvinfer.so.10 / version 10.9.0) but does not include companion builder resources. If nvvfx is imported first, the dynamic linker loads the 10.9.0 shared library. When other custom nodes (such as RIFE TensorRT) attempt to call tensorrt.Builder (which expects 10.12 in the environment), the builder references the preloaded 10.9.0 library, tries to search for the nonexistent libnvinfer_builder_resource.so.10.9.0, and fails to initialize (TypeError: pybind11::init(): factory function returned nullptr). Preloading tensorrt before nvvfx at startup solves this conflict by ensuring the environment's correct 10.12 shared libraries are loaded first.