### PR TITLE
fix: free dlpack tensor per-frame to prevent GPU memory leak in RTX VSR node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -92,8 +92,12 @@ class RTXVideoSuperResolution(io.ComfyNode):
 
                 for j in range(batch_cuda.shape[0]):
                     input_frame = batch_cuda[j]
-                    dlpack_out = sr.run(input_frame).image
-                    out_tensor[i + j: i + j + 1] = torch.from_dlpack(dlpack_out).movedim(0, -1).unsqueeze(0)
+                    result = sr.run(input_frame)
+                    dlpack_out = result.image
+                    out_frame = torch.from_dlpack(dlpack_out).movedim(0, -1).unsqueeze(0).clone()
+                    out_tensor[i + j: i + j + 1] = out_frame
+                    del dlpack_out, result, out_frame
+                    torch.cuda.empty_cache()
 
         return io.NodeOutput(out_tensor)
 


### PR DESCRIPTION
## The problem, from the user's seat

You drop a 200-frame video into ComfyUI, wire it through the `RTX Video Super Resolution` node, hit Queue, and walk away. A minute later `nvidia-smi` shows VRAM pegged at 100%, the ComfyUI prompt stops making progress, and the only way out is to kill the process. Short batches are fine — the node sings on 10 frames. It's only once you get past ~60 frames that it slowly suffocates.

This is exactly what andypotato reported in #16: *"When upscaling batches of images it will slowly eat up all my system memory. At some point it will start swapping and then spiral the system into swapping death loop. Usually it happens around 60 - 70 images upscaled."* It's been open and reproducible for a while. Tracked in the new issue #35.

## What's actually leaking

In `__init__.py`, the `execute()` loop calls `sr.run(input_frame)` per frame and converts the returned dlpack tensor via `torch.from_dlpack()`:

```python
for j in range(batch_cuda.shape[0]):
    input_frame = batch_cuda[j]
    dlpack_out = sr.run(input_frame).image
    out_tensor[i + j: i + j + 1] = torch.from_dlpack(dlpack_out).movedim(0, -1).unsqueeze(0)
```

The problem: `torch.from_dlpack(dlpack_out)` produces a PyTorch GPU tensor that **shares** the dlpack's underlying storage. The `dlpack_out` variable gets overwritten on the next iteration, but neither the dlpack capsule nor the PyTorch view that aliases it is ever explicitly released. The `.movedim()` / `.unsqueeze()` calls produce *views*, not new allocations, so the original per-frame storage stays pinned for the life of the loop. The CUDA caching allocator holds onto all of it, VRAM climbs monotonically, and eventually the node OOMs or deadlocks on a blocking CUDA call.

## The fix

Three small changes to the per-frame loop, all about giving the allocator a chance to reclaim memory each iteration:

1. **`.clone()` the converted tensor** — breaks the aliasing so the output owns its own storage and the dlpack-backed tensor becomes immediately releasable.
2. **`del dlpack_out, result, out_frame`** — drops the references this iteration instead of waiting for the frame to go out of scope.
3. **`torch.cuda.empty_cache()`** — returns the now-freed blocks to the GPU so the next frame starts from a clean slate.

```python
for j in range(batch_cuda.shape[0]):
    input_frame = batch_cuda[j]
    result = sr.run(input_frame)
    dlpack_out = result.image
    out_frame = torch.from_dlpack(dlpack_out).movedim(0, -1).unsqueeze(0).clone()
    out_tensor[i + j: i + j + 1] = out_frame
    del dlpack_out, result, out_frame
    torch.cuda.empty_cache()
```

## Verification

Tested locally with 100+ frame runs where the original code OOM'd around ~60 frames. With this patch VRAM stays flat across the whole run — `nvidia-smi` holds a steady plateau instead of the old monotonic climb. Output is pixel-identical (`.clone()` is a copy, not a transform).

There's a small per-frame cost from `empty_cache()` (it forces a synchronisation), but for the video use case this is the difference between "works" and "hangs the whole session." If the overhead matters on someone's workload it's easy to gate behind an interval (e.g. every N frames) — happy to do that if the maintainers prefer.

## Scope

- One file changed: `__init__.py`
- No API or behaviour change for existing graphs — same inputs, same outputs, just without the memory leak.

Closes #35. Related: #16.
