### PR TITLE
Reduce memory pressure and fix DLPack lifetime in RTX VSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Nvidia_RTX_Nodes_ComfyUI
 
-Contains the "RTX Video Super Resolution" upscaling node to upscale images and videos. Only works on Nvidia RTX GPUs. 
+Contains the **RTX Video Super Resolution** node for upscaling images and videos with NVIDIA RTX Video Effects. Only NVIDIA RTX GPUs are supported.
 
-Search RTX in the ComfyUI manager to install it.
+Search **RTX** in the ComfyUI Manager to install it.
+
+## Memory behavior
+
+High-resolution video outputs can be much larger than their inputs. The node processes VSR one frame at a time so CUDA scratch memory does not scale with an arbitrary frame batch.
+
+`output_device` controls where the complete returned `IMAGE` tensor lives:
+
+- `auto` (default): keeps the result on CUDA when enough free VRAM exists for the full output plus conservative scratch/headroom; otherwise uses CPU.
+- `cuda`: always keep the complete result in VRAM. This is useful for large video chains when VRAM is plentiful and avoids materializing another full-resolution tensor in system RAM.
+- `cpu`: preserve host-memory output behavior.
+
+VideoHelperSuite's standard FFmpeg path iterates `IMAGE` frames and converts each frame to CPU individually before writing it to FFmpeg. With that path, a CUDA result avoids materializing a second complete full-resolution floating-point video tensor in system RAM. Formats that require their own pre-pass may retain encoded frame bytes separately.

--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,74 @@ class UpscaleType(str, Enum):
     TARGET_DIMENSIONS = "target dimensions"
 
 
+class OutputDevice(str, Enum):
+    AUTO = "auto"
+    CUDA = "cuda"
+    CPU = "cpu"
+
+
+_GIB = 1024**3
+_AUTO_CUDA_MIN_HEADROOM = 2 * _GIB
+_AUTO_CUDA_HEADROOM_FRACTION = 0.10
+
+
+def _tensor_nbytes(shape, dtype: torch.dtype) -> int:
+    elements = 1
+    for dimension in shape:
+        elements *= int(dimension)
+    return elements * torch.empty((), dtype=dtype).element_size()
+
+
+def _resolve_output_device(
+    images: torch.Tensor,
+    output_shape: tuple[int, int, int, int],
+    preference: str,
+) -> torch.device:
+    preference = str(preference).lower()
+    if preference == OutputDevice.CPU.value:
+        return torch.device("cpu")
+
+    if not torch.cuda.is_available():
+        if preference == OutputDevice.CUDA.value:
+            raise RuntimeError("RTX Video Super Resolution output_device=cuda requires CUDA")
+        return torch.device("cpu")
+
+    cuda_device = images.device if images.device.type == "cuda" else torch.device("cuda")
+    if preference == OutputDevice.CUDA.value:
+        return cuda_device
+    if preference != OutputDevice.AUTO.value:
+        raise ValueError(f"Unsupported output device: {preference}")
+
+    # Auto checks the complete output against free VRAM after NVVFX has loaded.
+    # This remains necessary when the input itself is already CUDA: a downstream
+    # 2x VSR output is 4x the input pixel storage and can otherwise turn a useful
+    # zero-copy chain into a GPU OOM.
+    try:
+        free_bytes, total_bytes = torch.cuda.mem_get_info(cuda_device)
+    except Exception:
+        return torch.device("cpu")
+
+    _, output_height, output_width, channels = output_shape
+    input_frame_shape = (1, int(images.shape[1]), int(images.shape[2]), int(images.shape[3]))
+    output_frame_shape = (1, output_height, output_width, channels)
+    output_bytes = _tensor_nbytes(output_shape, images.dtype)
+    # Peak frame scratch while cloning the effect-owned DLPack result consists
+    # of one float32 input frame plus both the NVVFX output and its owned clone.
+    # The final copy writes directly into out_tensor, including dtype conversion,
+    # so it does not create another full-size converted output tensor.
+    scratch_bytes = (
+        _tensor_nbytes(input_frame_shape, torch.float32)
+        + 2 * _tensor_nbytes(output_frame_shape, torch.float32)
+    )
+    headroom = max(
+        _AUTO_CUDA_MIN_HEADROOM,
+        int(total_bytes * _AUTO_CUDA_HEADROOM_FRACTION),
+    )
+    if free_bytes >= output_bytes + scratch_bytes + headroom:
+        return cuda_device
+    return torch.device("cpu")
+
+
 class RTXVideoSuperResolution(io.ComfyNode):
     class UpscaleTypedDict(TypedDict):
         resize_type: UpscaleType
@@ -42,6 +110,20 @@ class RTXVideoSuperResolution(io.ComfyNode):
                     ],
                 ),
                 io.Combo.Input("quality", options=["LOW", "MEDIUM", "HIGH", "ULTRA"], default="ULTRA"),
+                io.Combo.Input(
+                    "output_device",
+                    options=[
+                        OutputDevice.AUTO.value,
+                        OutputDevice.CUDA.value,
+                        OutputDevice.CPU.value,
+                    ],
+                    default=OutputDevice.AUTO.value,
+                    tooltip=(
+                        "auto keeps the complete upscaled video in VRAM when enough CUDA memory "
+                        "is free, avoiding a second full-resolution system-RAM tensor. cpu keeps "
+                        "legacy host-memory output behavior."
+                    ),
+                ),
             ],
             outputs=[
                 io.Image.Output("upscaled_images"),
@@ -49,8 +131,19 @@ class RTXVideoSuperResolution(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, images: torch.Tensor, resize_type: UpscaleTypedDict, quality: str) -> io.NodeOutput:
-        b, h, w, c = images.shape
+    def execute(
+        cls,
+        images: torch.Tensor,
+        resize_type: UpscaleTypedDict,
+        quality: str,
+        output_device: str = OutputDevice.AUTO.value,
+    ) -> io.NodeOutput:
+        if not torch.is_tensor(images) or images.ndim != 4:
+            raise ValueError("images must be an IMAGE tensor [frames,height,width,channels]")
+
+        frame_count, h, w, c = images.shape
+        if frame_count < 1:
+            return io.NodeOutput(images)
 
         selected_type = resize_type["resize_type"]
         if selected_type == UpscaleType.SCALE_BY:
@@ -65,11 +158,7 @@ class RTXVideoSuperResolution(io.ComfyNode):
 
         output_width = max(8, round(output_width / 8) * 8)
         output_height = max(8, round(output_height / 8) * 8)
-
-        MAX_PIXELS = 1024 * 1024 * 16
-
-        out_pixels = output_width * output_height
-        batch_size = max(1, MAX_PIXELS // out_pixels)
+        output_shape = (int(frame_count), output_height, output_width, int(c))
 
         quality_mapping = {
             "LOW": nvvfx.effects.QualityLevel.LOW,
@@ -78,22 +167,45 @@ class RTXVideoSuperResolution(io.ComfyNode):
             "ULTRA": nvvfx.effects.QualityLevel.ULTRA,
         }
         selected_quality = quality_mapping.get(quality, nvvfx.effects.QualityLevel.HIGH)
+        cuda_device = images.device if images.device.type == "cuda" else torch.device("cuda")
 
-        with nvvfx.VideoSuperRes(selected_quality) as sr:
+        with torch.inference_mode(), nvvfx.VideoSuperRes(selected_quality) as sr:
             sr.output_width = output_width
             sr.output_height = output_height
             sr.load()
 
-            out_tensor = torch.empty((images.shape[0], output_height, output_width, c), device=images.device, dtype=images.dtype)
-            for i in range(0, images.shape[0], batch_size):
-                batch = images[i:i + batch_size]
+            # Resolve auto after the effect is loaded so its resident allocations
+            # are already reflected in the free-VRAM measurement.
+            result_device = _resolve_output_device(images, output_shape, output_device)
 
-                batch_cuda = batch.cuda().permute(0, 3, 1, 2).float().contiguous()
-
-                for j in range(batch_cuda.shape[0]):
-                    input_frame = batch_cuda[j]
-                    dlpack_out = sr.run(input_frame).image
-                    out_tensor[i + j: i + j + 1] = torch.from_dlpack(dlpack_out).movedim(0, -1).unsqueeze(0)
+            # The returned IMAGE must be one contiguous tensor, but there is no reason
+            # to pre-stage a multi-frame float32 CUDA batch as well. Process exactly one
+            # frame at a time so temporary memory is O(one frame) instead of O(batch).
+            out_tensor = torch.empty(
+                output_shape,
+                device=result_device,
+                dtype=images.dtype,
+            )
+            for index in range(int(frame_count)):
+                # copy=True plus contiguous_format produces exactly one owned,
+                # contiguous float32 CUDA input frame even when the source is a
+                # non-contiguous movedim view or already lives on CUDA.
+                input_frame = images[index].movedim(-1, 0).to(
+                    device=cuda_device,
+                    dtype=torch.float32,
+                    memory_format=torch.contiguous_format,
+                    copy=True,
+                )
+                result = sr.run(input_frame)
+                dlpack_out = result.image
+                # NVVFX owns the DLPack-backed storage and may reuse/free it on
+                # the next run() or when the effect closes. Clone immediately so
+                # all downstream copies read from PyTorch-owned storage.
+                output_frame = torch.from_dlpack(dlpack_out).clone().movedim(0, -1)
+                # copy_ supports cross-device and dtype conversion, avoiding a
+                # separate full-size output_frame.to(...) temporary on CUDA.
+                out_tensor[index].copy_(output_frame)
+                del input_frame, output_frame, dlpack_out, result
 
         return io.NodeOutput(out_tensor)
 


### PR DESCRIPTION
## Summary

This reduces memory pressure in long/high-resolution `RTX Video Super Resolution` workflows and fixes the NVVFX DLPack output lifetime without adding per-frame CUDA allocator flushes.

The change is intentionally limited to the existing RTX VSR node and its README documentation.

## Problems addressed

The current implementation has three separate memory/lifetime costs:

1. The returned `IMAGE` tensor is allocated on `images.device`. In normal CPU-backed ComfyUI image chains, that materializes the entire upscaled video in system RAM even when the next consumer can accept a CUDA `IMAGE` tensor.
2. Frames are grouped by pixel count and the whole group is converted to float32 CUDA before inference, so temporary CUDA memory scales with the selected batch rather than one frame.
3. `VideoSuperRes.run()` returns DLPack-backed storage owned by NVVFX. The frame must establish PyTorch-owned storage before that effect-owned buffer can be reused or torn down. This is the lifetime issue tracked in #35 and targeted by #36.

For video chains that already perform a latent spatial upscale before VSR, the final pixel tensor can become very large. A 2x latent spatial upscale followed by 2x VSR produces 16x the original pixel count, so unnecessarily retaining another complete float32 RGB video in host memory can mean tens of GiB.

## Changes

- Process VSR exactly one frame at a time instead of pre-staging a multi-frame float32 CUDA batch.
- Build each NVVFX input as one owned contiguous float32 CUDA frame rather than a `.to(...).contiguous()` chain that can require two CUDA temporaries.
- Clone each NVVFX DLPack result immediately, keep the NVVFX result alive through the copy, and release the per-frame references before the next `run()`.
- Copy the owned output frame directly into the preallocated result tensor with `copy_`, including device/dtype conversion, avoiding another full-frame `output_frame.to(...)` temporary.
- Do **not** call `torch.cuda.empty_cache()` per frame. Released PyTorch blocks remain reusable by the caching allocator without forcing a synchronization/allocation cycle every frame. This incorporates the outstanding review feedback on #36.
- Add an append-only `output_device` control:
  - `auto` (default): keep the full result on CUDA only when current free VRAM can hold the output, peak per-frame scratch, and conservative headroom; otherwise use CPU.
  - `cuda`: explicitly keep the complete result in VRAM.
  - `cpu`: explicitly keep the complete result in system RAM.
- Resolve `auto` only after `VideoSuperRes.load()` so NVVFX resident allocations are already reflected in the free-VRAM measurement.
- Account for the actual explicit CUDA peak in `auto`: one float32 input frame plus the simultaneously-live NVVFX float32 output and owned float32 clone, in addition to the complete returned tensor and conservative headroom.
- Perform the fit check even when the input is already CUDA, since the larger VSR output may not fit just because its input does.
- Preserve the input dtype in the returned `IMAGE` tensor.
- Validate the `[frames, height, width, channels]` contract and preserve empty inputs.
- Document the memory/output-device behavior.

## Compatibility

- `nvvfx.VideoSuperRes` remains the inference backend.
- Quality mapping is unchanged.
- Scale-by and target-dimensions behavior is unchanged, including 8-pixel output alignment.
- The node still returns one ComfyUI `IMAGE` tensor.
- `output_device` is appended to the schema and `execute()` supplies a default, so existing workflows that do not serialize the new input continue to have a valid call signature.
- Explicit CPU output remains available for downstream nodes that require host tensors.

VideoHelperSuite's current standard FFmpeg path iterates the `IMAGE` tensor frame by frame and converts each frame to CPU before writing it to FFmpeg. That path therefore does not require a second complete floating-point host tensor when this node returns CUDA output. Formats that require a pre-pass may retain encoded frame bytes separately.

## Validation

- Based directly on current upstream `main` (`892515e3`, v0.1.3); the PR branch is exactly one commit ahead with no upstream drift.
- Manually exercised in the motivating long/high-resolution H3 -> RTX VSR workflow; the CUDA-output/DLPack-lifetime path is working successfully.
- Review follow-up validated the peak-allocation accounting and the PyTorch `copy_`/contiguous-copy behavior used by the final implementation.
- No GPU CI is available in this repository to exercise NVVFX inference automatically.

This includes the core owned-DLPack fix from #36 while also addressing the independent host-memory and batch-staging pressure. It deliberately omits #36's per-frame `torch.cuda.empty_cache()` because that call was also flagged in review as unnecessary allocator churn.

Closes #35.
Addresses #16.
Related: #36.